### PR TITLE
Fix typographical error(s)

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ buffer config ( only work `producer_type` = "async" )
 * `batch_size`
 
     Specifies the `send.buffer.bytes`. Default `1M`(may reach 2M).
-    Be carefull, *SHOULD* be smaller than the `socket.request.max.bytes / 2 - 10k` config in kafka server.
+    Be careful, *SHOULD* be smaller than the `socket.request.max.bytes / 2 - 10k` config in kafka server.
 
 * `max_buffering`
 


### PR DESCRIPTION
@doujiang24, I've corrected a typographical error in the documentation of the [lua-resty-kafka](https://github.com/doujiang24/lua-resty-kafka) project. Specifically, I've changed carefull to careful. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.