### PR TITLE
Removing : from client_id, breaks in kafka 0.9

### DIFF
--- a/lib/resty/kafka/client.lua
+++ b/lib/resty/kafka/client.lua
@@ -179,7 +179,7 @@ function _M.new(self, broker_list, client_config)
         broker_list = broker_list,
         topic_partitions = {},
         brokers = {},
-        client_id = "worker:" .. pid(),
+        client_id = "worker" .. pid(),
         socket_config = socket_config,
     }, mt)
 


### PR DESCRIPTION
Hello,

As detailed in this thread:

https://groups.google.com/forum/#!topic/confluent-platform/WhMhORdTDz0

the lua-resty-kafka library sets a client_id that includes a character considered invalid when used for autocreation of JMX metrics. I've edited this manually so that we can interoperate with kafka 0.9. 


