### PR TITLE
Add handler for successful send to Kafka

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 t/servroot
+.idea/
+*.iml

--- a/README.md
+++ b/README.md
@@ -261,13 +261,21 @@ buffer config ( only work `producer_type` = "async" )
 
 * `error_handle`
 
-    Specifies the error handle, handle data when buffer send to kafka error.
-    `syntax: error_handle = function (topic, partition_id, message_queue, index, err, retryable) end`,
-    the failed messages in the message_queue is like ```{ key1, msg1, key2, msg2 } ```,
-    `key` in the message_queue is empty string `""` even if orign is `nil`.
-    `index` is the message_queue length, should not use `#message_queue`.
-    when `retryable` is `true` that means kafka server surely not committed this messages, you can safely retry to send;
+    Specifies function to handle any error when buffer sent to kafka.
+    Syntax: `error_handle = function (topic, partition_id, message_queue, index, err, retryable) <function body> end`,
+    `topic` and `partition_id` identify destination of failed messages,
+    Failed messages in the message_queue is like ```{ key1, msg1, key2, msg2 } ```,
+    `key` in the message_queue is empty string `""` even if origin is `nil`.
+    `index` is the message_queue length, should not use `#message_queue` due its structure.
+    When `retryable` is `true` that means kafka server surely not committed this messages, you can safely retry to send;
     and else means maybe, recommend to log to somewhere.
+    
+* `success_handle`
+    
+    Specifies function to handle successful send of message buffer to kafka.
+    Syntax: `success_handle = function (topic, count) <function body> end`
+    `topic` is destination topic and
+    `count` is equal to count of messages successfully sent to named topic
 
 Not support compression now.
 

--- a/lib/resty/kafka/producer.lua
+++ b/lib/resty/kafka/producer.lua
@@ -337,13 +337,28 @@ _timer_flush = function (premature, self, time)
 end
 
 
+local function shuffleTable(t)
+    local rand = math.random
+    local iterations = #t
+    local j
+
+    for i = iterations, 2, -1 do
+        j = rand(i)
+        t[i], t[j] = t[j], t[i]
+    end
+end
+
 function _M.new(self, broker_list, producer_config, cluster_name)
+    math.randomseed( os.time() )
+
     local name = cluster_name or DEFAULT_CLUSTER_NAME
     local opts = producer_config or {}
     local async = opts.producer_type == "async"
     if async and cluster_inited[name] then
         return cluster_inited[name]
     end
+
+    shuffleTable(broker_list)
 
     local cli = client:new(broker_list, producer_config)
     local p = setmetatable({

--- a/lib/resty/kafka/producer.lua
+++ b/lib/resty/kafka/producer.lua
@@ -250,7 +250,7 @@ local function _flush(premature, self)
 
     if not all_done then
         -- two possible cases:
-        --      1. all messages are sent previouslyb and therefore buffer is empty and nothing to send
+        --      1. all messages are sent previously and therefore buffer is empty and nothing to send
         --      2. messages not sent, buffer is not empty, real error occured
         for topic, partition_id, buffer in sendbuffer:loop() do
             local queue, index, err, retryable = buffer.queue, buffer.index, buffer.err, buffer.retryable

--- a/lib/resty/kafka/sendbuffer.lua
+++ b/lib/resty/kafka/sendbuffer.lua
@@ -202,24 +202,4 @@ function _M.aggregator(self, client)
     return num, sendbroker
 end
 
-function _M.deepcopy(self, orig)
-    local orig_type = type(orig)
-    local copy
-    if orig_type == 'table' then
-        copy = {}
-        for orig_key, orig_value in next, orig, nil do
-            copy[self:deepcopy(orig_key)] = self:deepcopy(orig_value)
-        end
-        setmetatable(copy, self:deepcopy(getmetatable(orig)))
-    else -- number, string, boolean, etc
-    copy = orig
-    end
-    return copy
-end
-
-function _M.copyfrom(self, other)
-    local new = self:deepcopy(other)
-    return new
-end
-
 return _M

--- a/lib/resty/kafka/sendbuffer.lua
+++ b/lib/resty/kafka/sendbuffer.lua
@@ -2,8 +2,10 @@
 
 
 local setmetatable = setmetatable
+local getmetatable = getmetatable
 local pairs = pairs
 local next = next
+local type = type
 
 
 local ok, new_tab = pcall(require, "table.new")
@@ -200,5 +202,24 @@ function _M.aggregator(self, client)
     return num, sendbroker
 end
 
+function _M.deepcopy(self, orig)
+    local orig_type = type(orig)
+    local copy
+    if orig_type == 'table' then
+        copy = {}
+        for orig_key, orig_value in next, orig, nil do
+            copy[self:deepcopy(orig_key)] = self:deepcopy(orig_value)
+        end
+        setmetatable(copy, self:deepcopy(getmetatable(orig)))
+    else -- number, string, boolean, etc
+    copy = orig
+    end
+    return copy
+end
+
+function _M.copyfrom(self, other)
+    local new = self:deepcopy(other)
+    return new
+end
 
 return _M

--- a/lib/resty/kafka/sendbuffer.lua
+++ b/lib/resty/kafka/sendbuffer.lua
@@ -2,10 +2,8 @@
 
 
 local setmetatable = setmetatable
-local getmetatable = getmetatable
 local pairs = pairs
 local next = next
-local type = type
 
 
 local ok, new_tab = pcall(require, "table.new")
@@ -201,5 +199,6 @@ function _M.aggregator(self, client)
 
     return num, sendbroker
 end
+
 
 return _M


### PR DESCRIPTION
## Goal of proposed change:

ability to control successful sending to Kafka, which is vital for monitoring of complex pipelines. 
E.g. metric reporting placed in error and success handles to log number of published and failed messages to monitoring or logging facility.
## What was changed:
1. in case of successful sending, handling of this case is added. We call successful handler if any or write to log with Nginx logging API.
2. additional case triggers error handler. This occurs when we have no partitions metadata (brokers are down), but still have non empty message queue.
3. shuffle function for tables
4. broker list shuffled on each producer:new call
