### PR TITLE
Add kafka 0.10 support for producer

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,7 +232,8 @@ producer config, most like in <http://kafka.apache.org/documentation.html#produc
 
 * `api_version`
 
-    Specifies the produce API version. Default `2`. This requires Kafka server 0.10.0.0 or above.
+    Specifies the produce API version. Default `0`.
+    If you use Kafka 0.10.0.0 or higher, `api_version` can use `0`, `1` or `2`.
     If you use Kafka 0.9.x, `api_version` should be `0` or `1`.
     If you use Kafka 0.8.x, `api_version` should be `0`.
 

--- a/README.md
+++ b/README.md
@@ -230,6 +230,12 @@ producer config, most like in <http://kafka.apache.org/documentation.html#produc
     `syntax: partitioner = function (key, partition_num, correlation_id) end`,
     the correlation_id is an auto increment id in producer. Default partitioner is:
 
+* `api_version`
+
+    Specifies the produce API version. Default `2`. This requires Kafka server 0.10.0.0 or above.
+    If you use Kafka 0.9.x, `api_version` should be `0` or `1`.
+    If you use Kafka 0.8.x, `api_version` should be `0`.
+
 
 ```lua
 local function default_partitioner(key, num, correlation_id)

--- a/lib/resty/kafka/broker.lua
+++ b/lib/resty/kafka/broker.lua
@@ -62,7 +62,7 @@ function _M.send_receive(self, request)
 
     sock:setkeepalive(self.config.keepalive_timeout, self.config.keepalive_size)
 
-    return response:new(data), nil, true
+    return response:new(data, request.api_version), nil, true
 end
 
 

--- a/lib/resty/kafka/producer.lua
+++ b/lib/resty/kafka/producer.lua
@@ -23,6 +23,9 @@ local crc32 = ngx.crc32_short
 local pcall = pcall
 local pairs = pairs
 
+local API_VERSION_V0 = 0
+local API_VERSION_V1 = 1
+local API_VERSION_V2 = 2
 
 local ok, new_tab = pcall(require, "table.new")
 if not ok then
@@ -95,12 +98,13 @@ local function produce_decode(resp)
         for j = 1, partition_num do
             local partition = resp:int32()
 
-            if api_version == request.API_VERSION_V0 or api_version == request.API_VERSION_V1 then
+            if api_version == API_VERSION_V0 or api_version == API_VERSION_V1 then
                 ret[topic][partition] = {
                     errcode = resp:int16(),
                     offset = resp:int64(),
                 }
-            elseif api_version == request.API_VERSION_V2 then
+
+            elseif api_version == API_VERSION_V2 then
                 ret[topic][partition] = {
                     errcode = resp:int16(),
                     offset = resp:int64(),
@@ -329,7 +333,7 @@ function _M.new(self, broker_list, producer_config, cluster_name)
         required_acks = opts.required_acks or 1,
         partitioner = opts.partitioner or default_partitioner,
         error_handle = opts.error_handle,
-        api_version = opts.api_version or request.API_VERSION_V2,
+        api_version = opts.api_version or API_VERSION_V0,
         async = async,
         socket_config = cli.socket_config,
         ringbuffer = ringbuffer:new(opts.batch_num or 200, opts.max_buffering or 50000),   -- 200, 50K

--- a/lib/resty/kafka/producer.lua
+++ b/lib/resty/kafka/producer.lua
@@ -58,7 +58,7 @@ end
 
 local function produce_encode(self, topic_partitions)
     local req = request:new(request.ProduceRequest,
-                            correlation_id(self), self.client.client_id)
+                            correlation_id(self), self.client.client_id, self.api_version)
 
     req:int16(self.required_acks)
     req:int32(self.request_timeout)
@@ -83,6 +83,7 @@ end
 local function produce_decode(resp)
     local topic_num = resp:int32()
     local ret = new_tab(0, topic_num)
+    local api_version = resp.api_version
 
     for i = 1, topic_num do
         local topic = resp:string()
@@ -90,13 +91,22 @@ local function produce_decode(resp)
 
         ret[topic] = {}
 
+        -- ignore ThrottleTime
         for j = 1, partition_num do
             local partition = resp:int32()
 
-            ret[topic][partition] = {
-                errcode = resp:int16(),
-                offset = resp:int64(),
-            }
+            if api_version == request.API_VERSION_V0 or api_version == request.API_VERSION_V1 then
+                ret[topic][partition] = {
+                    errcode = resp:int16(),
+                    offset = resp:int64(),
+                }
+            elseif api_version == request.API_VERSION_V2 then
+                ret[topic][partition] = {
+                    errcode = resp:int16(),
+                    offset = resp:int64(),
+                    timestamp = resp:int64(), -- If CreateTime is used, this field is always -1
+                }
+            end
         end
     end
 
@@ -319,6 +329,7 @@ function _M.new(self, broker_list, producer_config, cluster_name)
         required_acks = opts.required_acks or 1,
         partitioner = opts.partitioner or default_partitioner,
         error_handle = opts.error_handle,
+        api_version = opts.api_version or request.API_VERSION_V2,
         async = async,
         socket_config = cli.socket_config,
         ringbuffer = ringbuffer:new(opts.batch_num or 200, opts.max_buffering or 50000),   -- 200, 50K

--- a/lib/resty/kafka/request.lua
+++ b/lib/resty/kafka/request.lua
@@ -21,9 +21,9 @@ local MESSAGE_VERSION_0 = 0
 local MESSAGE_VERSION_1 = 1
 
 
-_M.API_VERSION_V0 = 0
-_M.API_VERSION_V1 = 1
-_M.API_VERSION_V2 = 2
+local API_VERSION_V0 = 0
+local API_VERSION_V1 = 1
+local API_VERSION_V2 = 2
 
 _M.ProduceRequest = 0
 _M.FetchRequest = 1
@@ -69,7 +69,7 @@ end
 
 function _M.new(self, apikey, correlation_id, client_id, api_version)
     local c_len = #client_id
-    api_version = api_version or _M.API_VERSION_V0
+    api_version = api_version or API_VERSION_V0
 
     local req = {
         0,   -- request size: int32
@@ -152,7 +152,6 @@ local function message_package(key, msg, message_version)
     local key = key or ""
     local key_len = #key
     local len = #msg
-    message_version = message_version or MESSAGE_VERSION_0
 
     local req
     local head_len
@@ -169,6 +168,7 @@ local function message_package(key, msg, message_version)
             msg,
         }
         head_len = 22
+
     else
         req = {
             -- MagicByte
@@ -195,7 +195,7 @@ function _M.message_set(self, messages, index)
     local index = index or #messages
 
     local message_version = MESSAGE_VERSION_0
-    if self.api_key == _M.ProduceRequest and self.api_version == _M.API_VERSION_V2 then
+    if self.api_key == _M.ProduceRequest and self.api_version == API_VERSION_V2 then
         message_version = MESSAGE_VERSION_1
     end
 

--- a/lib/resty/kafka/response.lua
+++ b/lib/resty/kafka/response.lua
@@ -17,8 +17,6 @@ local _M = {}
 local mt = { __index = _M }
 
 function _M.new(self, str, api_version)
-    api_version = api_version or request.API_VERSION_V0
-
     local resp = setmetatable({
         str = str,
         offset = 1,

--- a/lib/resty/kafka/response.lua
+++ b/lib/resty/kafka/response.lua
@@ -2,6 +2,7 @@
 
 
 local bit = require "bit"
+local request = require "resty.kafka.request"
 
 
 local setmetatable = setmetatable
@@ -15,12 +16,14 @@ local strbyte = string.byte
 local _M = {}
 local mt = { __index = _M }
 
+function _M.new(self, str, api_version)
+    api_version = api_version or request.API_VERSION_V0
 
-function _M.new(self, str)
     local resp = setmetatable({
         str = str,
         offset = 1,
         correlation_id = 0,
+        api_version = api_version,
     }, mt)
 
     resp.correlation_id = resp:int32()

--- a/t/request.t
+++ b/t/request.t
@@ -84,7 +84,7 @@ ffff
                 req[func](req, number)
                 local str = correlation_id .. req._req[#req._req]
 
-                local resp = response:new(str)
+                local resp = response:new(str, req.api_version)
 
                 local cnumber = resp[func](resp)
 


### PR DESCRIPTION
Use Kafka produce API v2 and message v1 by default.
See also [A Guide To The Kafka Protocol](https://cwiki.apache.org/confluence/display/KAFKA/A+Guide+To+The+Kafka+Protocol).