### PR TITLE
added rockspec

### DIFF
--- a/lua-resty-kafka-0.07-0.rockspec
+++ b/lua-resty-kafka-0.07-0.rockspec
@@ -1,0 +1,36 @@
+package = "lua-resty-kafka"
+version = "0.07-0"
+source = {
+   url = "git://github.com/doujiang24/lua-resty-kafka",
+   tag = "v0.07"
+}
+description = {
+   summary = "Lua Kafka client driver for the ngx_lua based on the cosocket API",
+   detailed = [[
+     This Lua library is a Kafka client driver for the ngx_lua nginx module:
+
+     http://wiki.nginx.org/HttpLuaModule
+
+     This Lua library takes advantage of ngx_lua's cosocket API, which ensures 100% nonblocking behavior.
+
+     Note that at least ngx_lua 0.9.3 or ngx_openresty 1.4.3.7 is required, and unfortunately only LuaJIT supported (--with-luajit).
+   ]],
+   homepage = "https://github.com/doujiang24/lua-resty-kafka",
+   license = "BSD"
+}
+dependencies = {
+   "lua >= 5.1"
+}
+build = {
+   type = "builtin",
+   modules = {
+      ["resty.kafka.broker"] = "lib/resty/kafka/broker.lua",
+      ["resty.kafka.client"] = "lib/resty/kafka/client.lua",
+      ["resty.kafka.errors"] = "lib/resty/kafka/errors.lua",
+      ["resty.kafka.producer"] = "lib/resty/kafka/producer.lua",
+      ["resty.kafka.request"] = "lib/resty/kafka/request.lua",
+      ["resty.kafka.response"] = "lib/resty/kafka/response.lua",
+      ["resty.kafka.ringbuffer"] = "lib/resty/kafka/ringbuffer.lua",
+      ["resty.kafka.sendbuffer"] = "lib/resty/kafka/sendbuffer.lua"
+   }
+}


### PR DESCRIPTION
Hi, it would be great if this package was available in luarocks.

I've taken the liberty of creating a rockspec for it.

After merging it, the steps for publishing in luarocks would be:

* Creating a user in https://luarocks.org .
* Generate an API key for luarocks in https://luarocks.org/settings/api-keys
* Install luarocks locally
* `luarocks upload lua-resty-kafka-0.07-0.rockspec --api-key=<YOUR-API-KEY>`

Aside:

I have also noticed that my coworker @yskopets created a rockspec for 0.06 and uploaded it under his account: https://luarocks.org/modules/yskopets/lua-resty-kafka . Since it was the first one, it is now the "root" one (meaning that's the one people will get when they do `luarocks install lua-resty-kafka`, instead of yours). I can probably make that change so yours is the "root" instead, if that sort of thing interests you.