### PR TITLE
Add TLS support to kafka broker connections

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,8 @@ addons:
   apt:
     packages:
       - libtest-base-perl
-      - libtext-diff-perl 
-      - libipc-run3-perl 
+      - libtext-diff-perl
+      - libipc-run3-perl
       - liburi-perl
       - libwww-perl
       - libtest-longstring-perl
@@ -31,29 +31,35 @@ env:
 
 install:
   - git clone https://github.com/openresty/test-nginx.git ../test-nginx
-  - if [ ! -f download-cache/kafka_$SCALA_VER-$KAFKA_VER.tgz ]; then wget -P download-cache http://mirrors.tuna.tsinghua.edu.cn/apache/kafka/$KAFKA_VER/kafka_$SCALA_VER-$KAFKA_VER.tgz;fi
-  - if [ ! -f download-cache/apache-zookeeper-$ZK_VER-bin.tar.gz ]; then wget -P download-cache https://mirrors.tuna.tsinghua.edu.cn/apache/zookeeper/zookeeper-ZK_VER/apache-zookeeper-$ZK_VER-bin.tar.gz;fi
+  - if [ ! -f download-cache/kafka_$SCALA_VER-$KAFKA_VER.tgz ]; then wget -P download-cache https://archive.apache.org/dist/kafka/$KAFKA_VER/kafka_$SCALA_VER-$KAFKA_VER.tgz;fi
+  - if [ ! -f download-cache/apache-zookeeper-$ZK_VER-bin.tar.gz ]; then wget -P download-cache https://downloads.apache.org/zookeeper/zookeeper-$ZK_VER/apache-zookeeper-$ZK_VER-bin.tar.gz;fi
   - if [ ! -f download-cache/openresty-$OPENRESTY_VER.tar.gz ]; then wget -P download-cache https://openresty.org/download/openresty-$OPENRESTY_VER.tar.gz;fi
 
-script: 
+script:
   - sudo tar -xzf download-cache/apache-zookeeper-$ZK_VER-bin.tar.gz -C /usr/local/
   - sudo tar -xzf download-cache/kafka_$SCALA_VER-$KAFKA_VER.tgz -C /usr/local/
   - sudo mv /usr/local/kafka_$SCALA_VER-$KAFKA_VER /usr/local/kafka
   - sudo mv /usr/local/apache-zookeeper-$ZK_VER-bin /usr/local/zookeeper
   - sudo cp /usr/local/zookeeper/conf/zoo_sample.cfg /usr/local/zookeeper/conf/zoo.cfg
+  - sudo yes "" | keytool -genkeypair -keyalg RSA -dname "CN=127.0.0.1" -alias 127.0.0.1 -keystore selfsigned.jks -validity 365 -keysize 2048 -storepass changeit
+  - sudo mv selfsigned.jks /usr/local/selfsigned.jks; chmod 755 /usr/local/selfsigned.jks
   - sudo sed -i '$ahost\.name=127.0.0.1' /usr/local/kafka/config/server.properties
+  - sudo sed -i 's;#listeners=PLAINTEXT://:9092;listeners=PLAINTEXT://127.0.0.1:9092,SSL://127.0.0.1:9093;g' /usr/local/kafka/config/server.properties
+  - sudo sed -i '$assl\.keystore\.location = \/usr\/local\/selfsigned.jks' /usr/local/kafka/config/server.properties
+  - sudo sed -i '$assl\.keystore\.password = changeit' /usr/local/kafka/config/server.properties
+  - sudo sed -i '$assl\.key\.password = changeit' /usr/local/kafka/config/server.properties
   - sudo /usr/local/zookeeper/bin/zkServer.sh start
   - sudo /usr/local/kafka/bin/kafka-server-start.sh  -daemon /usr/local/kafka/config/server.properties
-  - sleep 1
+  - sleep 5
   - /usr/local/kafka/bin/kafka-topics.sh --create --zookeeper localhost:2181  --replication-factor 1 --partitions 2 --topic test
   - /usr/local/kafka/bin/kafka-topics.sh --create --zookeeper localhost:2181  --replication-factor 1 --partitions 2 --topic test2
   - /usr/local/kafka/bin/kafka-topics.sh --create --zookeeper localhost:2181  --replication-factor 1 --partitions 2 --topic test3
   - /usr/local/kafka/bin/kafka-topics.sh --create --zookeeper localhost:2181  --replication-factor 1 --partitions 2 --topic test4
   - /usr/local/kafka/bin/kafka-topics.sh --create --zookeeper localhost:2181  --replication-factor 1 --partitions 2 --topic test5
-  - tar -xzf download-cache/openresty-$OPENRESTY_VER.tar.gz 
-  - cd openresty-$OPENRESTY_VER 
-  - ./configure --prefix=/usr/local/openresty-debug --with-debug > build.log 2>&1 || (cat build.log && exit 1) 
-  - make -j$JOBS > build.log 2>&1 || (cat build.log && exit 1)  
-  - sudo make install > build.log 2>&1 || (cat build.log && exit 1) 
-  - cd .. 
+  - tar -xzf download-cache/openresty-$OPENRESTY_VER.tar.gz
+  - cd openresty-$OPENRESTY_VER
+  - ./configure --prefix=/usr/local/openresty-debug --with-debug > build.log 2>&1 || (cat build.log && exit 1)
+  - make -j$JOBS > build.log 2>&1 || (cat build.log && exit 1)
+  - sudo make install > build.log 2>&1 || (cat build.log && exit 1)
+  - cd ..
   - make test

--- a/Makefile
+++ b/Makefile
@@ -15,4 +15,3 @@ install: all
 
 test: all
 	PATH=$(OPENRESTY_PREFIX)/nginx/sbin:$$PATH prove -I ./../test-nginx/lib -r t/
-

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ This Lua library takes advantage of ngx_lua's cosocket API, which ensures
 
 Note that at least [ngx_lua 0.9.3](https://github.com/openresty/lua-nginx-module/tags) or [ngx_openresty 1.4.3.7](http://openresty.org/#Download) is required, and unfortunately only LuaJIT supported (`--with-luajit`).
 
+Note for `ssl` connections at least [ngx_lua 0.9.11](https://github.com/openresty/lua-nginx-module/tags) or [ngx_openresty 1.7.4.1](http://openresty.org/#Download) is required, and unfortunately only LuaJIT supported (`--with-luajit`).
 
 Synopsis
 ========
@@ -155,6 +156,13 @@ client config
 
     Specifies the time to auto refresh the metadata in milliseconds. Then metadata will not auto refresh if is nil.
 
+* `ssl`
+
+    Specifies if client should use ssl connection. Defaults to false. See: https://github.com/openresty/lua-nginx-module#tcpsocksslhandshake
+
+* `ssl_verify`
+
+    Specifies if client should perform SSL verification. Defaults to false. See: https://github.com/openresty/lua-nginx-module#tcpsocksslhandshake
 
 [Back to TOC](#table-of-contents)
 
@@ -200,7 +208,7 @@ It's recommend to use async producer_type.
 
 An optional options table can be specified. The following options are as follows:
 
-`socket_timeout`, `keepalive_timeout`, `keepalive_size`, `refresh_interval` are the same as in `client_config`
+`socket_timeout`, `keepalive_timeout`, `keepalive_size`, `refresh_interval`, `ssl`, `ssl_verify`  are the same as in `client_config`
 
 producer config, most like in <http://kafka.apache.org/documentation.html#producerconfigs>
 
@@ -388,4 +396,3 @@ See Also
 * the [sarama](https://github.com/Shopify/sarama)
 
 [Back to TOC](#table-of-contents)
-

--- a/lib/resty/kafka/broker.lua
+++ b/lib/resty/kafka/broker.lua
@@ -35,6 +35,15 @@ function _M.send_receive(self, request)
         return nil, err, true
     end
 
+    if self.config.ssl then
+        -- TODO: add reused_session for better performance of short-lived connections
+        local _, err = sock:sslhandshake(false, self.host, self.config.ssl_verify)
+        if err then
+            return nil, "failed to do SSL handshake with " ..
+                        self.host .. ":" .. tostring(self.port) .. ": " .. err, true
+        end
+    end
+
     local bytes, err = sock:send(request:package())
     if not bytes then
         return nil, err, true

--- a/lib/resty/kafka/client.lua
+++ b/lib/resty/kafka/client.lua
@@ -173,6 +173,8 @@ function _M.new(self, broker_list, client_config)
         socket_timeout = opts.socket_timeout or 3000,
         keepalive_timeout = opts.keepalive_timeout or 600 * 1000,   -- 10 min
         keepalive_size = opts.keepalive_size or 2,
+        ssl = opts.ssl or false,
+        ssl_verify = opts.ssl_verify or false
     }
 
     local cli = setmetatable({

--- a/lua-resty-kafka-0.09-0.rockspec
+++ b/lua-resty-kafka-0.09-0.rockspec
@@ -1,8 +1,8 @@
 package = "lua-resty-kafka"
-version = "0.08-0"
+version = "0.09-0"
 source = {
    url = "git://github.com/doujiang24/lua-resty-kafka",
-   tag = "v0.08"
+   tag = "v0.09"
 }
 description = {
    summary = "Lua Kafka client driver for the ngx_lua based on the cosocket API",


### PR DESCRIPTION
Add optional support for TLS and TLS verification for Kafka connections.

References: 
https://github.com/openresty/lua-nginx-module#tcpsocksslhandshake
https://github.com/Kong/kong/blob/master/kong/plugins/http-log/handler.lua#L78
https://github.com/ledgetech/lua-resty-http/blob/master/lib/resty/http.lua#L174

@doujiang24 What do you think? Can you push out the new version too to luarocks if you agree this is good to go? 