### PR TITLE
Configurable host name resolving

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ client config
 
 * `resolver`
 
-    Specifies a host to ip resolving map (as a table or anything indexable). Default `nil`, no resolving performed. Example `{ some_host = "10.11.12.13" }`
+    Specifies a function to host resolving, which returns a string of IP or `nil`, to override system default host resolver. Default `nil`, no resolving performed. Example `function(host) if host == "some_host" then return "10.11.12.13" end end`
 
 [Back to TOC](#table-of-contents)
 

--- a/README.md
+++ b/README.md
@@ -318,6 +318,10 @@ buffer config ( only work `producer_type` = "async" )
     when `retryable` is `true` that means kafka server surely not committed this messages, you can safely retry to send;
     and else means maybe, recommend to log to somewhere.
 
+* `resolver`
+
+    Specifies a host to ip resolving map (as a table or anything indexable). Default `nil`, no resolving performed.
+
 Not support compression now.
 
 The third optional `cluster_name` specifies the name of the cluster, default `1` (yeah, it's number). You can Specifies different names when you have two or more kafka clusters. And this only works with `async` producer_type.

--- a/README.md
+++ b/README.md
@@ -187,6 +187,10 @@ client config
 
     Specifies if client should perform SSL verification. Defaults to false. See: https://github.com/openresty/lua-nginx-module#tcpsocksslhandshake
 
+* `resolver`
+
+    Specifies a host to ip resolving map (as a table or anything indexable). Default `nil`, no resolving performed. Example `{ some_host = "10.11.12.13" }`
+
 [Back to TOC](#table-of-contents)
 
 #### fetch_metadata
@@ -317,10 +321,6 @@ buffer config ( only work `producer_type` = "async" )
     `index` is the message_queue length, should not use `#message_queue`.
     when `retryable` is `true` that means kafka server surely not committed this messages, you can safely retry to send;
     and else means maybe, recommend to log to somewhere.
-
-* `resolver`
-
-    Specifies a host to ip resolving map (as a table or anything indexable). Default `nil`, no resolving performed.
 
 Not support compression now.
 

--- a/lib/resty/kafka/client.lua
+++ b/lib/resty/kafka/client.lua
@@ -189,8 +189,7 @@ local function _fetch_metadata(self, new_topic)
             -- we have been referred to. This injects the SASL auth in.
             for _, b in pairs(brokers) do
                 b.sasl_config = sasl_config
-                local h = b.host
-                b.host = sc.resolver and sc.resolver(h) or h
+                b.host = sc.resolver and sc.resolver(b.host) or b.host
             end
             self.brokers, self.topic_partitions = brokers, topic_partitions
 

--- a/lib/resty/kafka/client.lua
+++ b/lib/resty/kafka/client.lua
@@ -176,7 +176,7 @@ local function _fetch_metadata(self, new_topic)
         local host, port, sasl_config = broker_list[i].host,
                                         broker_list[i].port,
                                         broker_list[i].sasl_config
-        host = sc.resolver or sc.resolver(host) or host
+        host = sc.resolver and sc.resolver(host) or host
         local bk = broker:new(host, port, sc, sasl_config)
 
         local resp, err = bk:send_receive(req)


### PR DESCRIPTION
I have a case in my company project that requires resolving hardcoded host names and found quite a few issues with similar need like #5 #27 #28 #52 #57 . So I proceeded to make the following extension to support passing a `resolver` config table in client.

I run the patch in production, but I find it hard to be tested with automation script, so testing is a bit lacking in this PR. Kindly review to see if it's applicable. Thank you.