### PR TITLE
Fix bug, Kafka brokers start from index 0

### DIFF
--- a/lib/resty/kafka/client.lua
+++ b/lib/resty/kafka/client.lua
@@ -146,7 +146,7 @@ local function _fetch_metadata(self, new_topic)
             local brokers, topic_partitions = metadata_decode(resp)
             -- Confluent Cloud need the SASL auth on all requests, including to brokers
             -- we have been referred to. This injects the SASL auth in.
-            for j = 1, #brokers do
+            for j, _ in pairs(brokers) do
                 brokers[j].sasl_config = sasl_config
             end
             self.brokers, self.topic_partitions = brokers, topic_partitions

--- a/lib/resty/kafka/client.lua
+++ b/lib/resty/kafka/client.lua
@@ -146,8 +146,8 @@ local function _fetch_metadata(self, new_topic)
             local brokers, topic_partitions = metadata_decode(resp)
             -- Confluent Cloud need the SASL auth on all requests, including to brokers
             -- we have been referred to. This injects the SASL auth in.
-            for j, _ in pairs(brokers) do
-                brokers[j].sasl_config = sasl_config
+            for k, _ in pairs(brokers) do
+                brokers[k].sasl_config = sasl_config
             end
             self.brokers, self.topic_partitions = brokers, topic_partitions
 

--- a/lib/resty/kafka/client.lua
+++ b/lib/resty/kafka/client.lua
@@ -146,8 +146,8 @@ local function _fetch_metadata(self, new_topic)
             local brokers, topic_partitions = metadata_decode(resp)
             -- Confluent Cloud need the SASL auth on all requests, including to brokers
             -- we have been referred to. This injects the SASL auth in.
-            for k, _ in pairs(brokers) do
-                brokers[k].sasl_config = sasl_config
+            for _, b in pairs(brokers) do
+                b.sasl_config = sasl_config
             end
             self.brokers, self.topic_partitions = brokers, topic_partitions
 


### PR DESCRIPTION
We changed to use `pairs` to fix brokers index start from 1.