### PR TITLE
feat: support fetch broker ApiVersions

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - feat-apiversions
   pull_request:
     branches:
       - main

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - feat-apiversions
   pull_request:
     branches:
       - main

--- a/README.md
+++ b/README.md
@@ -213,6 +213,7 @@ When `min_version` and `max_version` are provided, it will act as a limit and th
 
 Tip: The version selection strategy is to choose the maximum version within the allowed range.
 
+
 [Back to TOC](#table-of-contents)
 
 resty.kafka.producer

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Table of Contents
             * [new](#new)
             * [fetch_metadata](#fetch_metadata)
             * [refresh](#refresh)
+            * [choose_api_version](#choose_api_version)
     * [resty.kafka.producer](#restykafkaproducer)
         * [Methods](#methods)
             * [new](#new)
@@ -199,6 +200,18 @@ This will refresh the metadata of all topics which have been fetched by `fetch_m
 In case of success, return all brokers and all partitions of all topics.
 In case of errors, returns `nil` with a string describing the error.
 
+
+[Back to TOC](#table-of-contents)
+
+#### choose_api_version
+
+`syntax: api_version = c:choose_api_version(api_key, min_version, max_version)`
+
+This helps the client to select the correct version of the `api_key` corresponding to the API.
+
+When `min_version` and `max_version` are provided, it will act as a limit and the selected versions in the return value will not exceed their limits no matter how high or low the broker supports the API version. When they are not provided, it will follow the range of versions supported by the broker.
+
+Tip: The version selection strategy is to choose the maximum version within the allowed range.
 
 [Back to TOC](#table-of-contents)
 

--- a/lib/resty/kafka/client.lua
+++ b/lib/resty/kafka/client.lua
@@ -115,7 +115,7 @@ end
 
 local function api_versions_encode(client_id)
     local id = 0    -- hard code correlation_id
-    return request:new(request.ApiVersionsRequest, id, client_id, request.API_VERSION_V0)
+    return request:new(request.ApiVersionsRequest, id, client_id, request.API_VERSION_V2)
 end
 
 
@@ -176,8 +176,7 @@ local function _fetch_metadata(self, new_topic)
             self.brokers, self.topic_partitions = brokers, topic_partitions
 
             -- fetch ApiVersions for compatibility
-            local req = api_versions_encode(self.client_id)
-            local resp, err = bk:send_receive(req)
+            local resp, err = bk:send_receive(api_versions_encode(self.client_id))
             if not resp then
                 ngx_log(INFO, "broker fetch api versions failed, err:", err,
                           ", host: ", host, ", port: ", port)

--- a/lib/resty/kafka/client.lua
+++ b/lib/resty/kafka/client.lua
@@ -287,16 +287,20 @@ function _M.choose_api_version(self, api_key, min_version, max_version)
 
     local broker_min_version, broker_max_version = api_version.min_version, api_version.max_version
 
-    if broker_max_version < max_version then
-        if broker_max_version < min_version then
+    if min_version and max_version then
+        if broker_max_version < max_version then
+            if broker_max_version < min_version then
+                return -1
+            else
+                return broker_max_version
+            end
+        elseif broker_min_version > max_version then
             return -1
         else
-            return broker_max_version
+            return max_version
         end
-    elseif broker_min_version > max_version then
-        return -1
     else
-        return max_version
+        return broker_max_version
     end
 end
 

--- a/lib/resty/kafka/client.lua
+++ b/lib/resty/kafka/client.lua
@@ -196,10 +196,11 @@ local function _fetch_metadata(self, new_topic)
             if not api_versions then
                 ngx_log(INFO, "broker fetch api versions failed, err:", err,
                           ", host: ", broker.host, ", port: ", broker.port)
-            end
-            self.api_versions = api_versions
+            else
+                self.api_versions = api_versions
 
-            return brokers, topic_partitions, api_versions
+                return brokers, topic_partitions, api_versions
+            end
         end
     end
 

--- a/lib/resty/kafka/client.lua
+++ b/lib/resty/kafka/client.lua
@@ -276,4 +276,29 @@ function _M.choose_broker(self, topic, partition_id)
 end
 
 
+-- select the api version to use, the maximum version will
+-- be used within the allowed range
+function _M.choose_api_version(self, api_key, min_version, max_version)
+    local api_version = self.api_versions[api_key]
+
+    if not api_version then
+        return -1
+    end
+
+    local broker_min_version, broker_max_version = api_version.min_version, api_version.max_version
+
+    if broker_max_version < max_version then
+        if broker_max_version < min_version then
+            return -1
+        else
+            return broker_max_version
+        end
+    elseif broker_min_version > max_version then
+        return -1
+    else
+        return max_version
+    end
+end
+
+
 return _M

--- a/t/client.t
+++ b/t/client.t
@@ -269,16 +269,29 @@ qr/\"max_version\":/ and qr /\"min_version\":/
 
             local brokers, partitions = cli:fetch_metadata("test")
 
-            ngx.say(cli:choose_api_version(request.FetchRequest, 0, 0))
+            -- not input version range
+            ngx.say(cli:choose_api_version(request.FetchRequest))
+
+            -- not exist api_key
+            ngx.say(cli:choose_api_version(-1))
+
+            -- set max version to -1 to break version choose
+            ngx.say(cli:choose_api_version(request.FetchRequest, 0, -1))
+
+            -- set lower max version to limit the API version
             ngx.say(cli:choose_api_version(request.FetchRequest, 0, 5))
-            ngx.say(cli:choose_api_version(request.FetchRequest, 0, 12))
+            
+            -- set higher max version to use the highest API version supported by broker
+            ngx.say(cli:choose_api_version(request.FetchRequest, 0, 9999))
         ';
     }
 --- request
 GET /t
 --- response_body
+11
+-1
 -1
 5
-12
+11
 --- no_error_log
 [error]

--- a/t/client.t
+++ b/t/client.t
@@ -233,14 +233,14 @@ GET /t
 
             local cli = client:new(broker_list)
 
-            local brokers, partitions, api_versions = cli:fetch_metadata("test")
+            local brokers, partitions = cli:fetch_metadata("test")
             
-            ngx.say(cjson.encode(api_versions))
+            ngx.say(cjson.encode(cli.api_versions))
         ';
     }
 --- request
 GET /t
---- response_body_like
-.*replicas.*
+--- response_body eval
+qr/\"max_version\":/ and qr /\"min_version\":/
 --- no_error_log
 [error]

--- a/t/client.t
+++ b/t/client.t
@@ -211,3 +211,36 @@ GET /t
 .*replicas.*
 --- no_error_log
 [error]
+
+
+
+=== TEST 6: ApiVersions fetch
+--- http_config eval: $::HttpConfig
+--- config
+    location /t {
+        content_by_lua '
+
+            local cjson = require "cjson"
+            local client = require "resty.kafka.client"
+
+            local broker_list = {
+                { host = "$TEST_NGINX_KAFKA_HOST", port = $TEST_NGINX_KAFKA_PORT },
+            }
+
+            local messages = {
+                "halo world",
+            }
+
+            local cli = client:new(broker_list)
+
+            local brokers, partitions, api_versions = cli:fetch_metadata("test")
+            
+            ngx.say(cjson.encode(api_versions))
+        ';
+    }
+--- request
+GET /t
+--- response_body_like
+.*replicas.*
+--- no_error_log
+[error]


### PR DESCRIPTION
Support to get the API version supported by broker, It will help us to choose the correct API version for the call.

Because of the wrong CI trigger condition, this PR temporarily failed the GitHub Action test and another PR #127 has been submited. After that PR merge, I will rebase this PR to implement the test.