### PR TITLE
fix:  `api_version` not used while producing to kafka

### DIFF
--- a/lib/resty/kafka/producer.lua
+++ b/lib/resty/kafka/producer.lua
@@ -62,7 +62,7 @@ end
 
 local function produce_encode(self, topic_partitions)
     local version = request.API_VERSION_V1
-    if self.api_version != nil then
+    if not self.api_version then
       version = self.api_version 
     end
     local req = request:new(request.ProduceRequest,

--- a/lib/resty/kafka/producer.lua
+++ b/lib/resty/kafka/producer.lua
@@ -63,7 +63,7 @@ end
 local function produce_encode(self, topic_partitions)
     local version = request.API_VERSION_V1
     if not self.api_version then
-      version = self.api_version 
+        version = self.api_version 
     end
     local req = request:new(request.ProduceRequest,
                             correlation_id(self), self.client.client_id, version)

--- a/lib/resty/kafka/producer.lua
+++ b/lib/resty/kafka/producer.lua
@@ -61,8 +61,12 @@ end
 
 
 local function produce_encode(self, topic_partitions)
+    local version = request.API_VERSION_V1
+    if self.api_version != nil then
+      version = self.api_version 
+    end
     local req = request:new(request.ProduceRequest,
-                            correlation_id(self), self.client.client_id, request.API_VERSION_V1)
+                            correlation_id(self), self.client.client_id, version)
 
     req:int16(self.required_acks)
     req:int32(self.request_timeout)


### PR DESCRIPTION
redo #137

Fix the bug of timestamp when sending msg to kafka.