### PR TITLE
use semaphore:wait() if max_buffering is full

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,6 +329,17 @@ buffer config ( only work `producer_type` = "async" )
     when `retryable` is `true` that means kafka server surely not committed this messages, you can safely retry to send;
     and else means maybe, recommend to log to somewhere.
 
+* `wait_on_buffer_full`
+
+    Specifies whether to wait when the buffer queue is full, Default `false`.
+    When buffer queue is full, if option passed `true`, 
+    will use semaphore wait function to block coroutine until timeout or buffer queue has reduced,
+    Otherwise, return "buffer overflow" error with `false`.
+
+* `wait_buffer_timeout`
+
+    Specifies the max wait time when buffer is full, Default `5` seconds.
+
 Not support compression now.
 
 The third optional `cluster_name` specifies the name of the cluster, default `1` (yeah, it's number). You can Specifies different names when you have two or more kafka clusters. And this only works with `async` producer_type.

--- a/README.md
+++ b/README.md
@@ -335,6 +335,7 @@ buffer config ( only work `producer_type` = "async" )
     When buffer queue is full, if option passed `true`, 
     will use semaphore wait function to block coroutine until timeout or buffer queue has reduced,
     Otherwise, return "buffer overflow" error with `false`.
+    Notice, it could not be used in those phases which do not support yields, i.e. log phase.
 
 * `wait_buffer_timeout`
 

--- a/lib/resty/kafka/producer.lua
+++ b/lib/resty/kafka/producer.lua
@@ -342,7 +342,8 @@ function _M.new(self, broker_list, producer_config, cluster_name)
         async = async,
         socket_config = cli.socket_config,
         _timer_flushing_buffer = false,
-        ringbuffer = ringbuffer:new(opts.batch_num or 200, opts.max_buffering or 50000),   -- 200, 50K
+        ringbuffer = ringbuffer:new(opts.batch_num or 200, opts.max_buffering or 50000,
+                opts.buffer_filled_wait or false, opts.wait_timeout or 5),   -- 200, 50K, flase, 5s
         sendbuffer = sendbuffer:new(opts.batch_num or 200, opts.batch_size or 1048576)
                         -- default: 1K, 1M
                         -- batch_size should less than (MaxRequestSize / 2 - 10KiB)

--- a/lib/resty/kafka/producer.lua
+++ b/lib/resty/kafka/producer.lua
@@ -343,7 +343,7 @@ function _M.new(self, broker_list, producer_config, cluster_name)
         socket_config = cli.socket_config,
         _timer_flushing_buffer = false,
         ringbuffer = ringbuffer:new(opts.batch_num or 200, opts.max_buffering or 50000,
-                opts.buffer_filled_wait or false, opts.wait_timeout or 5),   -- 200, 50K, flase, 5s
+                opts.wait_on_buffer_full or false, opts.wait_buffer_timeout or 5),   -- 200, 50K, flase, 5s
         sendbuffer = sendbuffer:new(opts.batch_num or 200, opts.batch_size or 1048576)
                         -- default: 1K, 1M
                         -- batch_size should less than (MaxRequestSize / 2 - 10KiB)

--- a/lib/resty/kafka/ringbuffer.lua
+++ b/lib/resty/kafka/ringbuffer.lua
@@ -33,7 +33,7 @@ function _M.new(self, batch_num, max_buffering, wait_on_buffer_full, wait_buffer
 end
 
 
-function _M.try_wait_for_buffer_full(self)
+function _M.wait_when_buffer_full(self)
     local num = self.num
     local size = self.size
 
@@ -54,7 +54,7 @@ end
 
 
 function _M.add(self, topic, key, message)
-    local _, err = self:try_wait_for_buffer_full()
+    local _, err = self:wait_when_buffer_full()
     if err ~= nil then
         return nil, err
     end
@@ -75,7 +75,7 @@ function _M.add(self, topic, key, message)
 end
 
 
-function _M.try_release_buffer_wait(self)
+function _M.release_buffer_wait(self)
     if not self.wait_on_buffer_full then
         return nil
     end
@@ -105,7 +105,7 @@ function _M.pop(self)
 
     queue[start], queue[start + 1], queue[start + 2] = ngx_null, ngx_null, ngx_null
 
-    self:try_release_buffer_wait()
+    self:release_buffer_wait()
 
     return key, topic, message
 end

--- a/lib/resty/kafka/ringbuffer.lua
+++ b/lib/resty/kafka/ringbuffer.lua
@@ -64,13 +64,14 @@ function _M.add(self, topic, key, message)
 end
 
 
-function _M.release_buffer_wait(self, num)
+function _M.release_buffer_wait(self)
     if not self.wait_on_buffer_full then
         return
     end
 
+    -- It is enough to release a waiter as only one message pops up
     if self.sema:count() < 0 then
-        self.sema:post(num)
+        self.sema:post(1)
     end
 end
 
@@ -92,8 +93,7 @@ function _M.pop(self)
 
     queue[start], queue[start + 1], queue[start + 2] = ngx_null, ngx_null, ngx_null
 
-    -- It is enough to release a waiter as only one message pops up
-    self:release_buffer_wait(1)
+    self:release_buffer_wait()
 
     return key, topic, message
 end

--- a/t/ringbuffer.t
+++ b/t/ringbuffer.t
@@ -125,3 +125,125 @@ GET /t
 num:3
 --- no_error_log
 [error]
+
+
+
+=== TEST 4: wait buffer full
+--- http_config eval: $::HttpConfig
+--- config
+    location /t {
+        content_by_lua '
+            local ringbuffer = require "resty.kafka.ringbuffer"
+            local buffer = ringbuffer:new(1, 2, true, 2)
+
+            local function handler()
+                ngx.sleep(1)
+                local topic, key, message = buffer:pop()
+                ngx.say(topic, key, message)
+            end
+
+            buffer:add("topic1", "key1", "message1")
+            buffer:add("topic2", "key2", "message2")
+
+            ngx.thread.spawn(handler)
+
+            start = ngx.now()
+            local ok, err = buffer:add("topic3", "key3", "message3")
+            if not ok then
+                ngx.say("add err:", err)
+                return
+            end
+            assert((ngx.now()-start) >= 1)
+
+            for i = 1, 2 do
+                local topic, key, message = buffer:pop()
+                ngx.say(topic, key, message)
+            end
+        ';
+    }
+--- request
+GET /t
+--- response_body
+topic1key1message1
+topic2key2message2
+topic3key3message3
+--- no_error_log
+[error]
+
+
+
+=== TEST 5: wait buffer full with timeout
+--- http_config eval: $::HttpConfig
+--- config
+    location /t {
+        content_by_lua '
+            local ringbuffer = require "resty.kafka.ringbuffer"
+            local buffer = ringbuffer:new(1, 1, true, 2)
+
+            local function handler()
+                ngx.sleep(2.1)
+                local topic, key, message = buffer:pop()
+                ngx.say(topic, key, message)
+            end
+
+            buffer:add("topic1", "key1", "message1")
+            local co = ngx.thread.spawn(handler)
+
+            start = ngx.now()
+            local ok, err = buffer:add("topic3", "key3", "message3")
+            if not ok then
+                ngx.say("add err:", err)
+            end
+            assert((ngx.now()-start) >= 2)
+
+            ngx.thread.wait(co)
+
+            local topic, key, message = buffer:pop()
+            ngx.say(topic)
+        ';
+    }
+--- request
+GET /t
+--- response_body
+add err:buffer overflow timeout
+topic1key1message1
+nil
+--- no_error_log
+[error]
+
+
+
+=== TEST 6: wait buffer full with depth
+--- http_config eval: $::HttpConfig
+--- config
+    location /t {
+        content_by_lua '
+            local ringbuffer = require "resty.kafka.ringbuffer"
+            local buffer = ringbuffer:new(1, 2, true, 2)
+
+            buffer:add("topic1", "key1", "message1")
+            buffer:add("topic2", "key2", "message2")
+
+            local ok, err = buffer:add("topic3", "key3", "message3", nil, 11)
+            if not ok then
+                ngx.say("add err:", err)
+            end
+
+            for i = 1, 2 do
+                local topic, key, message = buffer:pop()
+                ngx.say(topic, key, message)
+            end
+
+            local topic, key, message = buffer:pop()
+            ngx.say(topic)
+        ';
+    }
+--- request
+GET /t
+--- response_body
+add err:buffer overflow and over max depth
+topic1key1message1
+topic2key2message2
+nil
+--- no_error_log
+[error]


### PR DESCRIPTION
When the producer.add function is executed, if max_buffering is full, you can use semaphore to wait instead of returning an "buffer overflow" directly. When the producer.add function is executed, continue to add to max_buffering