### PR TITLE
feature: support produce api v3

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,7 +282,8 @@ producer config, most like in <http://kafka.apache.org/documentation.html#produc
 * `api_version`
 
     Specifies the produce API version. Default `0`.
-    If you use Kafka 0.10.0.0 or higher, `api_version` can use `0`, `1` or `2`.
+    If you use Kafka 4.0 or higher, `api_version` should be `3`.
+    If you use Kafka 0.10.0.0 up to 3.x, `api_version` can use `0`, `1` or `2`.
     If you use Kafka 0.9.x, `api_version` should be `0` or `1`.
     If you use Kafka 0.8.x, `api_version` should be `0`.
 

--- a/lib/resty/kafka/producer.lua
+++ b/lib/resty/kafka/producer.lua
@@ -27,6 +27,7 @@ local pairs = pairs
 local API_VERSION_V0 = 0
 local API_VERSION_V1 = 1
 local API_VERSION_V2 = 2
+local API_VERSION_V3 = 3
 
 local ok, new_tab = pcall(require, "table.new")
 if not ok then
@@ -64,6 +65,9 @@ local function produce_encode(self, topic_partitions)
     local req = request:new(request.ProduceRequest,
                             correlation_id(self), self.client.client_id, self.api_version)
 
+    if self.api_version == API_VERSION_V3 then
+        req:string() -- transactional_id(NULL)
+    end
     req:int16(self.required_acks)
     req:int32(self.request_timeout)
     req:int32(topic_partitions.topic_num)
@@ -105,7 +109,7 @@ local function produce_decode(resp)
                     offset = resp:int64(),
                 }
 
-            elseif api_version == API_VERSION_V2 then
+            elseif api_version == API_VERSION_V2 or api_version == API_VERSION_V3 then
                 ret[topic][partition] = {
                     errcode = resp:int16(),
                     offset = resp:int64(),

--- a/lib/resty/kafka/request.lua
+++ b/lib/resty/kafka/request.lua
@@ -5,13 +5,22 @@ local ffi = require "ffi"
 local bit = require "bit"
 
 
+local protocol = require "resty.kafka.protocol.common"
+
+
 local setmetatable = setmetatable
 local concat = table.concat
+local lshift = bit.lshift
 local rshift = bit.rshift
+local arshift = bit.arshift
 local band = bit.band
+local bor = bit.bor
+local bxor = bit.bxor
 local char = string.char
 local crc32 = ngx.crc32_long
+local crc32c = protocol.crc32c
 local ngx_now = ngx.now
+local floor = math.floor
 local tonumber = tonumber
 
 
@@ -20,6 +29,7 @@ local mt = { __index = _M }
 
 local MESSAGE_VERSION_0 = 0
 local MESSAGE_VERSION_1 = 1
+local MESSAGE_VERSION_2 = 2
 
 
 local API_VERSION_V0 = 0
@@ -190,6 +200,120 @@ function _M.bytes(self, str)
     self.len = self.len + 4 + str_len
 end
 
+-- The following code is referenced in this section.
+-- https://github.com/Neopallium/lua-pb/blob/1253c85d7c67dc355ec8d827df74d72c4eee3e3f/pb/standard/pack.lua
+local function varint_next_byte(num)
+	if num >= 0 and num < 128 then return num end
+	local b = bor(band(num, 0x7F), 0x80)
+	return (b), varint_next_byte(rshift(num, 7))
+end
+
+
+local function varint64_next_byte_h_l(h, l)
+	if h ~= 0 then
+		-- encode lower 28 bits.
+		local b1 = bor(band(l, 0x7F), 0x80)
+		local b2 = bor(band(rshift(l, 7), 0x7F), 0x80)
+		local b3 = bor(band(rshift(l, 14), 0x7F), 0x80)
+		local b4 = bor(band(rshift(l, 21), 0x7F), 0x80)
+		-- encode 4 bits from low 32-bits and 3 bits from high 32-bits
+		local b5 = bor(band(rshift(l, 28), 0xF) + (band(h, 0x7) * 16), 0x80)
+		h = rshift(h, 3)
+		-- Use variable length encoding of
+		return b1, b2, b3, b4, b5, varint_next_byte(h)
+	end
+	-- No high bits.  Use variable length encoding of low bits.
+	return varint_next_byte(l)
+end
+
+
+local function str_varint64_cdata(num)
+	return char(varint64_next_byte_h_l(tonumber(num / 0x100000000), tonumber(num % 0x100000000)))
+end
+
+
+-- convert number to unsigned int32
+local function uint32(num)
+	return num % 0x100000000
+end
+
+
+local function str_varint64_num(num)
+	if num >= 0 and num <= 0xFFFFFFFF then
+		return char(varint_next_byte(num))
+	end
+	local h, l = uint32(floor(num / 0x100000000)), uint32(num)
+	return char(varint64_next_byte_h_l(h, l))
+end
+
+
+local function str_varint64(num)
+	if type(num) == 'number' then
+		return str_varint64_num(num)
+	end
+	return str_varint64_cdata(num)
+end
+
+
+local function str_varint32(num)
+	-- only use the lowest 32-bits
+	if num >= 0x100000000 then
+		num = num % 0x100000000
+	end
+	if type(num) == 'number' then
+		return str_varint64_num(num)
+	end
+	return str_varint64_cdata(num)
+end
+
+
+local function zigzag64(num)
+	num = num * 2
+	if num < 0 then
+		num = (-num) - 1
+	end
+	return num
+end
+
+
+local function zigzag32(num)
+	return bxor(lshift(num, 1), arshift(num, 31))
+end
+
+
+local function str_varint(num)
+    return str_varint32(zigzag32(num))
+end
+
+
+local function str_varlong(num)
+    return str_varint64(zigzag64(num))
+end
+
+
+function _M.varlong(self, num)
+    local req = self._req
+    local offset = self.offset
+
+    local str = str_varlong(num)
+    req[offset] = str
+
+    self.offset = offset + 1
+    self.len = self.len + #str
+end
+
+
+function _M.varint(self, num)
+    local req = self._req
+    local offset = self.offset
+
+    local str = str_varint(num)
+    req[offset] = str
+
+    self.offset = offset + 1
+    self.len = self.len + #str
+end
+
 
 local function message_package(key, msg, message_version)
     local key = key or ""
@@ -231,16 +355,10 @@ local function message_package(key, msg, message_version)
 end
 
 
-function _M.message_set(self, messages, index)
+local function message_set_v0_1(self, messages, index, message_version)
     local req = self._req
     local off = self.offset
     local msg_set_size = 0
-    local index = index or #messages
-
-    local message_version = MESSAGE_VERSION_0
-    if self.api_key == _M.ProduceRequest and self.api_version == API_VERSION_V2 then
-        message_version = MESSAGE_VERSION_1
-    end
 
     for i = 1, index, 2 do
         local crc32, str, msg_len = message_package(messages[i], messages[i + 1], message_version)
@@ -259,6 +377,92 @@ function _M.message_set(self, messages, index)
 
     self.offset = off + 1
     self.len = self.len + 4 + msg_set_size
+end
+
+
+local function str_record(key, msg, msgcnt)
+    key = key or ""
+    local str = concat {
+        str_int8(0),        -- attributes
+        str_varlong(0),     -- timestampDelta
+        str_varint(msgcnt), -- offsetDelta
+        str_varint(#key),   -- keyLength
+        key,                -- key
+        str_varint(#msg),   -- valueLength
+        msg,                -- value
+        str_varint(0),      -- headersCount
+    }
+    return str
+end
+
+
+local function str_record_batch(messages, index)
+    local req = {}
+
+    local off = 9
+    local record_count = 0
+    for i = 1, index, 2 do
+        local record = str_record(messages[i], messages[i + 1], record_count)
+        req[off] = str_varint(#record)  -- recordLength
+        req[off + 1] = record
+
+        record_count = record_count + 1
+        off = off + 2
+    end
+
+    req[1] = str_int16(0)                   -- attributes
+    req[2] = str_int32(record_count-1)      -- lastOffsetDelta
+    req[3] = str_int64(ngx_now() * 1000)    -- baseTimestamp
+    req[4] = str_int64(ngx_now() * 1000)    -- maxTimestamp
+    req[5] = str_int64(-1)              -- producerId
+    req[6] = str_int16(0)               -- producerEpoch
+    req[7] = str_int32(0)               -- baseSequence
+    req[8] = str_int32(record_count)    -- recordCount
+
+    local str = concat(req)
+    return str
+end
+
+
+local function message_set_v2(self, messages, index)
+    local req = self._req
+    local off = self.offset
+
+    local record_batch = str_record_batch(messages, index)
+    local message_size = 8 + 4 + 4 + 1 + 4 + #record_batch
+
+    -- https://kafka.apache.org/documentation.html#recordbatch
+    req[off + 0] = str_int32(message_size)          -- messageSize
+    req[off + 1] = str_int64(0)                     -- baseOffset
+    req[off + 2] = str_int32(message_size-(8+4))    -- batchLength
+    req[off + 3] = str_int32(0)                     -- partitionLeaderEpoch
+    req[off + 4] = str_int8(2)                      -- magic
+    req[off + 5] = str_int32(crc32c(record_batch))  -- crc
+    req[off + 6] = record_batch
+
+    self.offset = off + 7
+    self.len = self.len + 4 + message_size
+end
+
+
+function _M.message_set(self, messages, index)
+    local index = index or #messages
+
+    local message_version = MESSAGE_VERSION_0
+    if self.api_key == _M.ProduceRequest and self.api_version == API_VERSION_V2 then
+        message_version = MESSAGE_VERSION_1
+
+    elseif self.api_key == _M.ProduceRequest and self.api_version == API_VERSION_V3 then
+        message_version = MESSAGE_VERSION_2
+    end
+
+    if message_version == MESSAGE_VERSION_2 then
+        message_set_v2(self, messages, index)
+
+    else
+        message_set_v0_1(self, messages, index, message_version)
+    end
+
 end
 
 


### PR DESCRIPTION
lua-resty-kafka is not compatible with Kafka 4.0+.

Kafka 4.0 has removed support for the produce API versions v0-v2 and message formats v0-v1.

https://cwiki.apache.org/confluence/display/KAFKA/KIP-896%3A+Remove+old+client+protocol+API+versions+in+Kafka+4.0