### PR TITLE
fix: Incorrect retryable parameter passed to error_handler

### DIFF
--- a/lib/resty/kafka/producer.lua
+++ b/lib/resty/kafka/producer.lua
@@ -171,7 +171,7 @@ local function _send(self, broker_conf, topic_partitions)
                         err = Errors[errcode] or Errors[-1]
 
                         -- set retries according to the error list
-                        local retryable0 = retryable or err.retriable
+                        local retryable0 = err.retriable
 
                         local index = sendbuffer:err(topic, partition_id, err.msg, retryable0)
 

--- a/t/producer.t
+++ b/t/producer.t
@@ -410,11 +410,7 @@ GET /t
 --- config
     location /t {
         content_by_lua '
-
-            local cjson = require "cjson"
             local producer = require "resty.kafka.producer"
-            local self = {};
-
             local broker_list = {
                 { host = "$TEST_NGINX_KAFKA_HOST", port = $TEST_NGINX_KAFKA_PORT },
             }
@@ -430,11 +426,10 @@ GET /t
             local producer_config =
                 { producer_type = "async", max_retry = 1, batch_num = 1, error_handle = error_handle }
 
+            local p = producer:new(broker_list, producer_config)
+
             -- Assuming the Kafka max.request.size is set to 1MB
             local message = string.rep("a", 1024 * 1024)
-
-            local p = producer:new(broker_list, producer_config)
-            self.kafka_producer = p
 
             local offset, err = p:send("test", nil, message)
             if not offset then

--- a/t/producer.t
+++ b/t/producer.t
@@ -421,7 +421,7 @@ GET /t
 
             local error_handle = function(topic, partition_id, message_queue, index, err, retryable)
                 if retryable and err == "MESSAGE_TOO_LARGE" then
-                    ngx.log(ngx.ERR, "retryable is expected to be false when MESSAGE_TOO_LARGE occurs")
+                    ngx.log(ngx.ERR, "retryable is expected to be false when MESSAGE_TOO_LARGE error occurs")
                 else
                     ngx.log(ngx.WARN, "kafka send err: topic=", topic, ", partition_id=", partition_id, ", index=", index, ", err=", err)
                 end
@@ -445,7 +445,6 @@ GET /t
             ngx.say("offset: ", tostring(offset))
         ';
     }
---- ONLY
 --- request
 GET /t
 --- response_body_like


### PR DESCRIPTION
This PR aims to resolve the problem described in issue #174